### PR TITLE
Fix makedfs when built for Windows

### DIFF
--- a/tools/mkdfs/README.md
+++ b/tools/mkdfs/README.md
@@ -1,0 +1,13 @@
+# Building with GCC
+If building with GCC, please use the makefile in the root directory.
+
+# Building an EXE for Windows using MSVC
+If building for Windows, an extra file needs to be placed in the `include` directory (as it is not included as part of windows standard files)
+A known working version can be found at: `https://raw.githubusercontent.com/tronkko/dirent/master/include/dirent.h`
+
+
+To build the solution using From Powershell (with VS2017 installed), from the current directory, the following commands can be used:
+```
+call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+cl .\tools\mkdfs\mkdfs.c -I .\include\
+```

--- a/tools/mkdfs/mkdfs.c
+++ b/tools/mkdfs/mkdfs.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <errno.h>

--- a/tools/mkdfs/mkdfs.c
+++ b/tools/mkdfs/mkdfs.c
@@ -1,17 +1,27 @@
 #include <stdio.h>
-#include <stdlib.h>
-#include <dirent.h>
+#include <malloc.h>
 #include <sys/stat.h>
 #include <string.h>
 #include <errno.h>
 #include <stdint.h>
+
 #include <sys/types.h>
+#ifndef _MSC_VER
+#include <dirent.h>
 #include <sys/param.h>
+#else
+#include "dirent.h"
+#endif // !_MSC_VER
+
 #include "dragonfs.h"
 #include "dfsinternal.h"
 
+#ifndef _MSC_VER
 #if BYTE_ORDER == BIG_ENDIAN
 #define SWAPLONG(i) (i)
+#else
+#define SWAPLONG(i) (((uint32_t)(i & 0xFF000000) >> 24) | ((uint32_t)(i & 0x00FF0000) >>  8) | ((uint32_t)(i & 0x0000FF00) <<  8) | ((uint32_t)(i & 0x000000FF) << 24))
+#endif
 #else
 #define SWAPLONG(i) (((uint32_t)(i & 0xFF000000) >> 24) | ((uint32_t)(i & 0x00FF0000) >>  8) | ((uint32_t)(i & 0x0000FF00) <<  8) | ((uint32_t)(i & 0x000000FF) << 24))
 #endif
@@ -81,7 +91,7 @@ uint32_t add_file(const char * const file, uint32_t *size)
 
     printf("Adding '%s' to filesystem image.\n", file);
 
-    fp = fopen(file, "r");
+    fp = fopen(file, "rb");
 
     if(!fp)
     {
@@ -310,7 +320,7 @@ int main(int argc, char *argv[])
     }
 
     /* Write out filesystem */
-    FILE *fp = fopen(argv[1], "w");
+    FILE *fp = fopen(argv[1], "wb");
 
     if(!fp)
     {


### PR DESCRIPTION
makedfs doesnt work when built on Windows due to file operations adding a carriage return when on windows. The fix is to open the files in binary mode (e.g. rb instead of r and wb instead of w). There also issues with endianness.

This PR fixes https://github.com/DragonMinded/libdragon/issues/30